### PR TITLE
Added field for link in plugin panel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "bnomei/kirby3-redirects",
   "type": "kirby-plugin",
   "description": "Setup HTTP Status Code Redirects from within the Kirby Panel",
+  "homepage": "https://github.com/bnomei/kirby3-redirects",
   "version": "1.5.7",
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
Added root `homepage:` field to `composer.json` so that the plugin name is linked back to the repository when viewed in the Kirby 3 panel.