### PR TITLE
feat: Add domain-specific redirect support for multiple domains

### DIFF
--- a/blueprints/sections/redirects3xx.yml
+++ b/blueprints/sections/redirects3xx.yml
@@ -21,13 +21,24 @@ fields:
         label:
           en: "Status Code"
           de: "Status Code"
-        default: '301'
+        default: "301"
         type: select
         options:
-          '_300': '300: Multiple Choices'
-          '_301': '301: Moved Permanently'
-          '_302': '302: Found'
-          '_303': '303: See Other'
-          '_304': '304: Not Modified'
-          '_307': '307: Temporary Redirect'
-          '_308': '308: Permanent Redirect'
+          "_300": "300: Multiple Choices"
+          "_301": "301: Moved Permanently"
+          "_302": "302: Found"
+          "_303": "303: See Other"
+          "_304": "304: Not Modified"
+          "_307": "307: Temporary Redirect"
+          "_308": "308: Permanent Redirect"
+      domain:
+        label:
+          en: "Domain-Substring (optional)"
+          de: "Domain-Substring (optional)"
+        type: text
+        placeholder:
+          en: "e.g. example"
+          de: "z.B. example"
+        help:
+          en: "Leave empty for global redirects. Enter domain identifier (e.g. 'example' for example.com) to apply only to specific domains."
+          de: "Leer lassen für globale Redirects. Domain-Identifier eingeben (z.B. 'example' für example.com) um nur auf spezifische Domains anzuwenden."

--- a/classes/Redirects.php
+++ b/classes/Redirects.php
@@ -44,7 +44,7 @@ class Redirects
         }
 
         // make sure the request.uri starts with a /
-        $this->options['request.uri'] = '/'.ltrim($this->options['request.uri'], '/');
+        $this->options['request.uri'] = '/' . ltrim($this->options['request.uri'], '/');
 
         $this->loadRedirectsFromSource($this->options['map']);
         $this->addShieldToRedirects();
@@ -83,14 +83,16 @@ class Redirects
             return $this->options['redirects'];
         }
         // array_merge is not working properly here, so we do it manually
-        foreach ([
-            'shield.generic',
-            'shield.wordpress',
-            'shield.joomla',
-            'shield.drupal',
-            'shield.magento',
-            'shield.shopify',
-        ] as $shield) {
+        foreach (
+            [
+                'shield.generic',
+                'shield.wordpress',
+                'shield.joomla',
+                'shield.drupal',
+                'shield.magento',
+                'shield.shopify',
+            ] as $shield
+        ) {
             foreach ($this->options[$shield] as $redirect) {
                 $this->options['redirects'][] = $redirect;
             }
@@ -146,8 +148,10 @@ class Redirects
         $copy = $data;
         foreach ($change as $item) {
             foreach ($copy as $key => $redirect) {
-                if (A::get($redirect, 'fromuri') === A::get($item, 'fromuri') &&
-                    A::get($redirect, 'touri') === A::get($item, 'touri')) {
+                if (
+                    A::get($redirect, 'fromuri') === A::get($item, 'fromuri') &&
+                    A::get($redirect, 'touri') === A::get($item, 'touri')
+                ) {
                     unset($data[$key]);
                     break; // exit inner loop
                 }
@@ -228,10 +232,19 @@ class Redirects
         if (array_key_exists($requesturi, $map)) {
             $map = [$map[$requesturi]];
         }
+
+        $currentDomain = $this->getCurrentDomainIdentifier();
+
         foreach ($map as $redirect) {
-            if (! array_key_exists('fromuri', $redirect) ||
+            if (
+                ! array_key_exists('fromuri', $redirect) ||
                 ! array_key_exists('touri', $redirect)
             ) {
+                continue;
+            }
+
+            // Check if this redirect applies to the current domain
+            if (! $this->isDomainApplicable($redirect, $currentDomain)) {
                 continue;
             }
 
@@ -255,13 +268,69 @@ class Redirects
         return null;
     }
 
+    /**
+     * Check if a redirect applies to the current domain
+     * 
+     * @param array $redirect The redirect configuration
+     * @param string $currentDomain The current domain identifier (e.g., 'polizei-einstellungstest', 'ausbildungspark')
+     * @return bool True if redirect should be applied, false otherwise
+     */
+    private function isDomainApplicable(array $redirect, string $currentDomain): bool
+    {
+        $domain = A::get($redirect, 'domain', '');
+
+        // If no domain is specified (empty), this redirect applies globally
+        if (empty(trim($domain))) {
+            return true;
+        }
+
+        // Check if the current domain contains the specified domain identifier
+        return str_contains($currentDomain, trim($domain));
+    }
+
+    /**
+     * Get the current domain identifier from the request hostname
+     * 
+     * Examples:
+     * - polizei-einstellungstest.de → 'polizei-einstellungstest'
+     * - polizei-einstellungstest-de.ww → 'polizei-einstellungstest'
+     * - ausbildungspark.com → 'ausbildungspark'
+     * - ausbildungspark-de.ww → 'ausbildungspark'
+     * 
+     * @return string The domain identifier
+     */
+    private function getCurrentDomainIdentifier(): string
+    {
+        try {
+            $host = kirby()->request()->url()->host();
+        } catch (\Exception $e) {
+            // Fallback to main domain if host detection fails
+            return 'ausbildungspark';
+        }
+
+        // Extract first part of hostname before dot or dash+code
+        // Examples: polizei-einstellungstest-de.ww → polizei-einstellungstest
+        //           polizei-einstellungstest.de → polizei-einstellungstest
+        //           ausbildungspark-de.ww → ausbildungspark
+
+        // Remove TLD/domain suffix (everything after first dot)
+        $parts = explode('.', $host);
+        $domain = $parts[0];
+
+        // If domain contains hyphens followed by language code (e.g., -de, -en), remove that part
+        // Match pattern: -xx where xx is 1-3 chars (typical language codes)
+        $domain = preg_replace('/-[a-z]{1,3}$/', '', $domain);
+
+        return $domain;
+    }
+
     private function makeRelativePath(string $url): string
     {
         $siteurl = A::get($this->options, 'site.url');
         $sitebase = Url::path($siteurl, true, true);
         $url = $siteurl !== '/' ? str_replace($siteurl, '', $url) : $url;
 
-        return '/'.trim($sitebase.$url, '/');
+        return '/' . trim($sitebase . $url, '/');
     }
 
     private function getRequestURI(): string

--- a/classes/Redirects.php
+++ b/classes/Redirects.php
@@ -103,8 +103,23 @@ class Redirects
 
     private function buildLookup(): array
     {
-        $this->options['redirects'] = array_column($this->options['redirects'], null, 'fromuri');
-
+        // Keep all redirects (don't collapse by fromuri) to support domain-specific overrides
+        // Sort domain-specific redirects before global ones so scoped matches take precedence
+        $redirects = $this->options['redirects'];
+        
+        usort($redirects, function ($a, $b) {
+            $domainA = ! empty(trim(A::get($a, 'domain', '')));
+            $domainB = ! empty(trim(A::get($b, 'domain', '')));
+            
+            // Sort domain-specific (true) before global (false)
+            // In usort: negative = $a first, positive = $b first, 0 = equal
+            if ($domainA === $domainB) {
+                return 0; // maintain order for same priority
+            }
+            return $domainA ? -1 : 1; // domain-specific first
+        });
+        
+        $this->options['redirects'] = $redirects;
         return $this->options['redirects'];
     }
 
@@ -150,7 +165,8 @@ class Redirects
             foreach ($copy as $key => $redirect) {
                 if (
                     A::get($redirect, 'fromuri') === A::get($item, 'fromuri') &&
-                    A::get($redirect, 'touri') === A::get($item, 'touri')
+                    A::get($redirect, 'touri') === A::get($item, 'touri') &&
+                    A::get($redirect, 'domain') === A::get($item, 'domain')
                 ) {
                     unset($data[$key]);
                     break; // exit inner loop
@@ -205,9 +221,10 @@ class Redirects
         return $this->options['parent'];
     }
 
-    public static function isKnownValidRoute(string $path): bool
+    public static function isKnownValidRoute(string $path, string $domain = ''): bool
     {
-        return kirby()->cache('bnomei.redirects')->get(md5($path)) !== null;
+        $cacheKey = md5($path . $domain);
+        return kirby()->cache('bnomei.redirects')->get($cacheKey) !== null;
     }
 
     public static function flush(): bool
@@ -218,7 +235,10 @@ class Redirects
     public function checkForRedirect(?string $uri = null): ?Redirect
     {
         $requesturi = $uri ?? (string) $this->options['request.uri'];
-        if (static::isKnownValidRoute($requesturi)) {
+        $currentDomain = $this->getCurrentDomainIdentifier();
+        $cacheKey = md5($requesturi . $currentDomain);
+        
+        if (static::isKnownValidRoute($requesturi, $currentDomain)) {
             return null;
         }
 
@@ -228,14 +248,19 @@ class Redirects
         }
 
         $r = new Redirect;
-        // try direct lookup first and only do that in a match
-        if (array_key_exists($requesturi, $map)) {
-            $map = [$map[$requesturi]];
+        // Collect all redirects for this path (not just first match)
+        $candidates = [];
+        foreach ($map as $redirect) {
+            if (A::get($redirect, 'fromuri') === $requesturi) {
+                $candidates[] = $redirect;
+            }
+        }
+        // If no direct matches, check all redirects
+        if (empty($candidates)) {
+            $candidates = $map;
         }
 
-        $currentDomain = $this->getCurrentDomainIdentifier();
-
-        foreach ($map as $redirect) {
+        foreach ($candidates as $redirect) {
             if (
                 ! array_key_exists('fromuri', $redirect) ||
                 ! array_key_exists('touri', $redirect)
@@ -259,10 +284,11 @@ class Redirects
             }
         }
 
-        // no redirect found, flag as valid route
+        // no redirect found, flag as valid route per domain
         // so it is not checked again until the cache is flushed
-        kirby()->cache('bnomei.redirects')->set(md5($requesturi), [
+        kirby()->cache('bnomei.redirects')->set($cacheKey, [
             $requesturi,
+            $currentDomain,
         ]);
 
         return null;
@@ -292,9 +318,9 @@ class Redirects
      * Get the current domain identifier from the request hostname
      * 
      * Examples:
-     * - polizei-einstellungstest.de → 'polizei-einstellungstest'
+     * - www.polizei-einstellungstest.de → 'polizei-einstellungstest'
      * - polizei-einstellungstest-de.ww → 'polizei-einstellungstest'
-     * - ausbildungspark.com → 'ausbildungspark'
+     * - www.ausbildungspark.com → 'ausbildungspark'
      * - ausbildungspark-de.ww → 'ausbildungspark'
      * 
      * @return string The domain identifier
@@ -304,14 +330,22 @@ class Redirects
         try {
             $host = kirby()->request()->url()->host();
         } catch (\Exception $e) {
-            // Fallback to main domain if host detection fails
-            return 'ausbildungspark';
+            // Fallback to site.url if host detection fails
+            $siteurl = A::get($this->options, 'site.url', '');
+            if (! empty($siteurl)) {
+                $host = parse_url($siteurl, PHP_URL_HOST) ?? '';
+                if (empty($host)) {
+                    return '';
+                }
+            } else {
+                return '';
+            }
         }
 
-        // Extract first part of hostname before dot or dash+code
-        // Examples: polizei-einstellungstest-de.ww → polizei-einstellungstest
-        //           polizei-einstellungstest.de → polizei-einstellungstest
-        //           ausbildungspark-de.ww → ausbildungspark
+        // Remove www prefix if present
+        if (str_starts_with($host, 'www.')) {
+            $host = substr($host, 4);
+        }
 
         // Remove TLD/domain suffix (everything after first dot)
         $parts = explode('.', $host);


### PR DESCRIPTION
Add domain-specific redirect support for multi-site installations

Problem:

When running multiple domain variants (e.g. microsites) on the same Kirby CMS installation, redirect management becomes complex. Currently, all redirects are global and apply to every domain.

Use case: A single Kirby install serves multiple domains like example.com (main site), example-one.de (microsite), and example-two.de (microsite).

Each domain may need different redirect targets for the same old URL:

Old URL: /some-old-url

Redirect on main site goes to /some-new-url
Redirect on example-one microsite goes to /example-one-specific-new-url
Redirect on example-two microsite goes to /example-two-specific-new-url

Solution:

This patch adds an optional domain field to the redirect structure. No domain field means the redirect applies globally (backward compatible). With a domain value, the redirect only applies to that specific domain.

Changes:

Added domain field to redirect blueprint
Implemented domain-based filtering in checkForRedirect()
Added helper methods to detect current domain from request hostname

Example usage:

Old URL /old-url redirects globally to /global-new-url without domain field
Same URL /old-url redirects to /polizei-new-url only on polizei-einstellungstest.de with domain polizei-einstellungstest

All existing redirects continue to work without any modification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional domain field for redirects so admins can scope redirects to a specific domain (leave empty for global).
  * Domain-scoped redirects now take precedence over global redirects when matching requests.

* **Bug Fixes / Behavior Changes**
  * Redirect removal and matching now respect domain scope to avoid unintended global overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->